### PR TITLE
Cross-platform executable build with PyInstaller

### DIFF
--- a/.github/workflows/build-karbon.yaml
+++ b/.github/workflows/build-karbon.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feature/cross-platform-build
   workflow_dispatch:  # Manual trigger
 
 permissions:

--- a/.github/workflows/build-karbon.yaml
+++ b/.github/workflows/build-karbon.yaml
@@ -48,8 +48,13 @@ jobs:
       - name: Rename binary for upload
         shell: bash
         run: |
-          mkdir -p upload
-          cp dist/Karbon${{ matrix.extension }} upload/Karbon-${{ runner.os }}${{ matrix.extension }}
+            mkdir -p upload
+            if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+              cp -r "dist/Karbon.app" "upload/Karbon-${{ runner.os }}.app"
+            else
+              cp "dist/Karbon${{ matrix.extension }}" "upload/Karbon-${{ runner.os }}${{ matrix.extension }}"
+            fi
+
 
       - name: Get short commit hash
         id: vars

--- a/.github/workflows/build-karbon.yaml
+++ b/.github/workflows/build-karbon.yaml
@@ -12,7 +12,16 @@ permissions:
 
 jobs:
   build:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        extension: [".exe", "", ""]
+        pyinstaller-args: [
+          "--onefile --noconsole --name Karbon --icon=icon.ico",
+          "--onefile --noconsole --name Karbon",
+          "--onefile --windowed --name Karbon"
+        ]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -31,16 +40,16 @@ jobs:
 
       - name: Build executable with PyInstaller
         run: |
-          pyinstaller ui.py --onefile --noconsole --name Karbon --icon=icon.ico
+          pyinstaller ui.py ${{ matrix.pyinstaller-args }}
 
       - name: Rename binary for upload
         shell: bash
         run: |
           mkdir -p upload
-          if [[ "${{ runner.os }}" == "macOS" ]]; then
+          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             cp -r "dist/Karbon.app" "upload/Karbon-${{ runner.os }}.app"
           else
-            cp "dist/Karbon.exe" "upload/Karbon-${{ runner.os }}.exe"
+            cp "dist/Karbon${{ matrix.extension }}" "upload/Karbon-${{ runner.os }}${{ matrix.extension }}"
           fi
 
       - name: Get short commit hash


### PR DESCRIPTION
### Summary

This PR adds CI support to build standalone executables for:

- ✅ Windows
- ✅ Linux (Ubuntu)
- ✅ macOS

via GitHub Actions using a matrix strategy and PyInstaller.

### Changes Made
- Updated `.github/workflows/build-karbon.yaml` to use `os: [ubuntu-latest, windows-latest, macos-latest]`.
- Added logic to handle `.app` bundles on macOS gracefully (fixes cp error).
- Verified builds on fork before raising PR.
<img width="1850" height="710" alt="Screenshot 2025-07-23 142253" src="https://github.com/user-attachments/assets/7297a7ce-5fe4-42f7-9bff-2a0111aa34ec" />


> Note: This PR was tested independently before being raised to the upstream repo.
