### PR TITLE
Fix cross-platform PyInstaller build and temporarily remove macOS icon

### DIFF
--- a/.github/workflows/build-karbon.yaml
+++ b/.github/workflows/build-karbon.yaml
@@ -25,9 +25,9 @@ jobs:
             extension: ""
             pyinstaller-args: --onefile --noconsole --name Karbon
           - os: macos-latest
-            icon: icon.icns
+            icon: ""
             extension: .app
-            pyinstaller-args: python -m pyinstaller ui.py --onefile --noconsole --name Karbon
+            pyinstaller-args: --onefile --noconsole --name Karbon
 
 
 

--- a/.github/workflows/build-karbon.yaml
+++ b/.github/workflows/build-karbon.yaml
@@ -27,7 +27,8 @@ jobs:
           - os: macos-latest
             icon: icon.icns
             extension: .app
-            pyinstaller-args: --onefile --noconsole --name Karbon --icon=icon.icns
+            pyinstaller-args: pyinstaller ui.py --onefile --noconsole --name Karbon
+
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-karbon.yaml
+++ b/.github/workflows/build-karbon.yaml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-      - feature/cross-platform-build
-  workflow_dispatch:  # Manual trigger
 
 permissions:
   contents: write
@@ -29,8 +27,6 @@ jobs:
             extension: .app
             pyinstaller-args: --onefile --noconsole --name Karbon
 
-
-
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -50,7 +46,7 @@ jobs:
 
       - name: Build executable with PyInstaller
         run: |
-          pyinstaller ui.py ${{ matrix.pyinstaller-args }}
+          python -m pyinstaller ui.py ${{ matrix.pyinstaller-args }}
 
       - name: Rename binary for upload
         if: matrix.os != 'ubuntu-latest'

--- a/.github/workflows/build-karbon.yaml
+++ b/.github/workflows/build-karbon.yaml
@@ -15,12 +15,20 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        extension: [".exe", "", ""]
-        pyinstaller-args: [
-          "--onefile --noconsole --name Karbon --icon=icon.ico",
-          "--onefile --noconsole --name Karbon",
-          "--onefile --windowed --name Karbon"
-        ]
+        include:
+          - os: windows-latest
+            icon: icon.ico
+            extension: .exe
+            pyinstaller-args: --onefile --noconsole --name Karbon --icon=icon.ico
+          - os: ubuntu-latest
+            icon: ""  # Optional: Linux builds typically don't use icons
+            extension: ""
+            pyinstaller-args: --onefile --noconsole --name Karbon
+          - os: macos-latest
+            icon: icon.icns
+            extension: .app
+            pyinstaller-args: --onefile --noconsole --name Karbon --icon=icon.icns
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -43,13 +51,14 @@ jobs:
           pyinstaller ui.py ${{ matrix.pyinstaller-args }}
 
       - name: Rename binary for upload
+        if: matrix.os != 'ubuntu-latest'
         shell: bash
         run: |
           mkdir -p upload
           if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
             cp -r "dist/Karbon.app" "upload/Karbon-${{ runner.os }}.app"
           else
-            cp "dist/Karbon${{ matrix.extension }}" "upload/Karbon-${{ runner.os }}${{ matrix.extension }}"
+            cp "dist/Karbon.exe" "upload/Karbon-${{ runner.os }}.exe"
           fi
 
       - name: Get short commit hash

--- a/.github/workflows/build-karbon.yaml
+++ b/.github/workflows/build-karbon.yaml
@@ -27,7 +27,8 @@ jobs:
           - os: macos-latest
             icon: icon.icns
             extension: .app
-            pyinstaller-args: pyinstaller ui.py --onefile --noconsole --name Karbon
+            pyinstaller-args: python -m pyinstaller ui.py --onefile --noconsole --name Karbon
+
 
 
     runs-on: ${{ matrix.os }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pywebview
 tk
 meta-ai-api
 pyinstaller
+Pillow


### PR DESCRIPTION
### Summary
- Resolved build failures on macOS by temporarily removing the icon setting.
- Replaced direct `pyinstaller` command with `python -m pyinstaller` to avoid "script not found" errors.
- Cleaned up matrix strategy and ensured correct renaming of binaries per OS.

### Notes
- Workflow tested on `feature/cross-platform-build`.
- Builds successfully complete for Windows and Linux.
- macOS build passes with `.app` bundle and no icon.
<img width="1908" height="700" alt="Screenshot 2025-07-23 150049" src="https://github.com/user-attachments/assets/c1fad379-16c0-4455-a526-e81cb0b3e2e9" />

