### PR TITLE
cleanup: remove .url files created by windows

### DIFF
--- a/README.md.url
+++ b/README.md.url
@@ -1,2 +1,0 @@
-[InternetShortcut]
-URL=https://github.com/Rachel602144/Karbon/blob/main/README.md

--- a/assets.url
+++ b/assets.url
@@ -1,2 +1,0 @@
-[InternetShortcut]
-URL=https://github.com/Rachel602144/Karbon/tree/main/assets


### PR DESCRIPTION
I removed `README.md.url` and `assets.url`, which are internet shortcuts for a fork lol